### PR TITLE
Add HAR parser extension

### DIFF
--- a/crates/agenterra-core/src/har.rs
+++ b/crates/agenterra-core/src/har.rs
@@ -1,0 +1,103 @@
+//! HAR parsing utilities for deriving API endpoint information.
+//!
+//! This module provides a simple parser for HAR (HTTP Archive) files so
+//! that recorded network traffic can be transformed into high level
+//! endpoint metadata. The intent is to support automated generation of
+//! MCP tools by observing existing API calls in the browser or other
+//! clients.
+//!
+//! This is intentionally minimal and focused on extracting request method
+//! and path information. The resulting data can then be mapped into an
+//! OpenAPI context or other structures for further processing.
+
+use serde::Deserialize;
+use std::path::Path;
+use tokio::fs;
+use url::Url;
+
+use crate::Error;
+
+/// Top level structure for a HAR file.
+#[derive(Debug, Deserialize)]
+struct HarFile {
+    log: HarLog,
+}
+
+#[derive(Debug, Deserialize)]
+struct HarLog {
+    entries: Vec<HarEntry>,
+}
+
+#[derive(Debug, Deserialize)]
+struct HarEntry {
+    request: HarRequest,
+}
+
+#[derive(Debug, Deserialize)]
+struct HarRequest {
+    method: String,
+    url: String,
+}
+
+/// Parsed representation of a HAR file.
+pub struct HarContext {
+    entries: Vec<HarEntry>,
+}
+
+impl HarContext {
+    /// Load a HAR file from disk.
+    pub async fn from_file<P: AsRef<Path>>(path: P) -> crate::Result<Self> {
+        let content = fs::read_to_string(&path).await?;
+        let har: HarFile = serde_json::from_str(&content).map_err(|e| {
+            Error::config(format!("Failed to parse HAR {}: {}", path.as_ref().display(), e))
+        })?;
+        Ok(Self {
+            entries: har.log.entries,
+        })
+    }
+
+    /// Return unique endpoint operations discovered in the HAR.
+    pub fn unique_operations(&self) -> Vec<HarOperation> {
+        use std::collections::HashSet;
+        let mut ops = Vec::new();
+        let mut seen = HashSet::new();
+
+        for entry in &self.entries {
+            if let Ok(url) = Url::parse(&entry.request.url) {
+                let method = entry.request.method.to_uppercase();
+                let path = url.path().to_string();
+                if seen.insert((method.clone(), path.clone())) {
+                    ops.push(HarOperation { method, path });
+                }
+            }
+        }
+        ops
+    }
+}
+
+/// Simplified representation of an API call extracted from a HAR file.
+#[derive(Debug, PartialEq, Eq)]
+pub struct HarOperation {
+    pub method: String,
+    pub path: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    #[tokio::test]
+    async fn test_unique_operations() -> crate::Result<()> {
+        let manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        let base = manifest.parent().unwrap().parent().unwrap();
+        let har_path = base.join("tests/fixtures/har/sample.har");
+        let ctx = HarContext::from_file(&har_path).await?;
+        let ops = ctx.unique_operations();
+        assert_eq!(ops.len(), 2);
+        assert!(ops.contains(&HarOperation { method: "GET".into(), path: "/api/items".into() }));
+        assert!(ops.contains(&HarOperation { method: "POST".into(), path: "/api/items".into() }));
+        Ok(())
+    }
+}
+

--- a/crates/agenterra-core/src/lib.rs
+++ b/crates/agenterra-core/src/lib.rs
@@ -9,6 +9,7 @@ pub mod error;
 pub mod generate;
 pub mod manifest;
 pub mod openapi;
+pub mod har;
 pub mod templates;
 pub mod utils;
 
@@ -17,6 +18,7 @@ pub use crate::{
     error::{Error, Result},
     generate::generate,
     openapi::OpenApiContext,
+    har::{HarContext, HarOperation},
     templates::{TemplateDir, TemplateKind, TemplateManager, TemplateOptions},
 };
 

--- a/tests/fixtures/README.md
+++ b/tests/fixtures/README.md
@@ -26,6 +26,7 @@ To validate all fixture JSON files:
 
 ```bash
 jq . openapi/*.json
+jq . har/*.har
 ```
 
 ---
@@ -57,3 +58,10 @@ jq . openapi/*.json
 > You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
 
 If you redistribute this repository, please retain this notice and comply with the terms of the Apache 2.0 license.
+
+---
+
+## Sample HAR File
+
+- **har/sample.har** is a minimal HTTP Archive used for unit tests.
+- The file contains two example requests to demonstrate endpoint extraction.

--- a/tests/fixtures/har/sample.har
+++ b/tests/fixtures/har/sample.har
@@ -1,0 +1,18 @@
+{
+  "log": {
+    "entries": [
+      {
+        "request": {
+          "method": "GET",
+          "url": "https://example.com/api/items"
+        }
+      },
+      {
+        "request": {
+          "method": "POST",
+          "url": "https://example.com/api/items"
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- parse HAR files to extract API calls
- expose `HarContext` and `HarOperation` in core library
- document new fixture and add sample HAR
- test parsing logic

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_684caeadf3a88328afec8221b95afbc2