### PR TITLE
Add validate subcommand

### DIFF
--- a/crates/agenterra-cli/src/main.rs
+++ b/crates/agenterra-cli/src/main.rs
@@ -20,8 +20,9 @@ struct Cli {
 }
 
 #[derive(clap::Subcommand, Debug)]
+#[allow(clippy::large_enum_variant)]
 pub enum Commands {
-    // TODO: Add future subcommands here (e.g., Validate, ListTemplates, etc.)
+    // TODO: Add future subcommands here (e.g., ListTemplates, etc.)
     /// Scaffold a new MCP server from an OpenAPI spec
     Scaffold {
         /// Project name
@@ -52,6 +53,12 @@ pub enum Commands {
         /// Base URL of the OpenAPI specification (Optional)
         #[arg(long)]
         base_url: Option<Url>,
+    },
+    /// Validate an OpenAPI specification
+    Validate {
+        /// Path or URL to OpenAPI schema
+        #[arg(long)]
+        schema_path: String,
     },
 }
 
@@ -203,6 +210,14 @@ async fn main() -> anyhow::Result<()> {
                 "✅ Successfully generated server in: {}",
                 output_path.display()
             );
+        }
+        Commands::Validate { schema_path } => {
+            let spec = agenterra_core::openapi::OpenApiContext::from_file_or_url(schema_path)
+                .await
+                .map_err(|e| anyhow::anyhow!("Failed to load OpenAPI schema: {}", e))?;
+            spec.validate()
+                .map_err(|e| anyhow::anyhow!("Invalid OpenAPI schema: {}", e))?;
+            println!("✅ OpenAPI schema {} is valid", schema_path);
         }
     }
     Ok(())

--- a/crates/agenterra-core/src/builders/rust.rs
+++ b/crates/agenterra-core/src/builders/rust.rs
@@ -139,7 +139,7 @@ fn extract_response_schema(op: &OpenApiOperation) -> JsonValue {
         .and_then(|content| content.get("application/json"))
         .and_then(|c| c.get("schema"))
         .cloned()
-        .unwrap_or_else(|| JsonValue::Null)
+        .unwrap_or(JsonValue::Null)
 }
 
 fn extract_properties_schema(op: &OpenApiOperation) -> JsonMap<String, JsonValue> {
@@ -154,7 +154,7 @@ fn extract_response_properties(op: &OpenApiOperation) -> JsonValue {
     extract_response_schema(op)
         .get("properties")
         .cloned()
-        .unwrap_or_else(|| JsonValue::Null)
+        .unwrap_or(JsonValue::Null)
 }
 
 fn build_property_info(op: &OpenApiOperation) -> Vec<RustPropertyInfo> {

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -8,6 +8,7 @@ This document provides a comprehensive reference for the Agenterra command-line 
 - [Global Options](#global-options)
 - [Commands](#commands)
   - [scaffold](#scaffold)
+  - [validate](#validate)
 - [Examples](#examples)
 - [Exit Codes](#exit-codes)
 
@@ -57,6 +58,14 @@ agenterra scaffold --spec api.yaml --output generated --template custom --templa
 
 # Configure server port and log file
 agenterra scaffold --spec api.yaml --output generated --port 8080 --log-file my-server
+```
+
+### validate
+
+Validate an OpenAPI specification without generating any code.
+
+```bash
+agenterra validate --schema-path <SPEC>
 ```
 
 ## Exit Codes


### PR DESCRIPTION
## Summary
- add `validate` subcommand to CLI
- expose `OpenApiContext::validate` for basic spec checks
- document validation command in CLI reference
- support new command in integration tests

## Testing
- `cargo clippy -- -D warnings`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_684e61d7009883288244bd54afb136de