### PR TITLE
Implement interactive init command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,6 +24,7 @@ dependencies = [
  "agenterra-core",
  "anyhow",
  "clap",
+ "dialoguer",
  "lazy_static",
  "log",
  "reqwest",
@@ -307,6 +308,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
+name = "console"
+version = "0.15.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "unicode-width",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -373,6 +387,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "abd57806937c9cc163efc8ea3910e00a62e2aeb0b8119f1793a978088f8f6b04"
 
 [[package]]
+name = "dialoguer"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "658bce805d770f407bc62102fca7c2c64ceef2fbcb2b8bd19d2765ce093980de"
+dependencies = [
+ "console",
+ "shell-words",
+ "tempfile",
+ "thiserror 1.0.69",
+ "zeroize",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -413,6 +440,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "encoding_rs"
@@ -1589,6 +1622,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shell-words"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2033,6 +2072,12 @@ name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a1a07cc7db3810833284e8d372ccdc6da29741639ecc70c9ec107df0fa6154c"
 
 [[package]]
 name = "unsafe-libyaml"
@@ -2552,6 +2597,12 @@ dependencies = [
  "syn",
  "synstructure",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
 
 [[package]]
 name = "zerotrie"

--- a/README.md
+++ b/README.md
@@ -37,6 +37,12 @@
 
 ### Method 1: Build & Run from Source
 
+Run an interactive wizard with:
+
+```bash
+agenterra init
+```
+
 ```bash
 # Clone the repository
 git clone https://github.com/clafollett/agenterra.git

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -48,7 +48,7 @@
 - [ ] Example generation
 
 ### 4. Developer Experience (Q4 2025)
-- [ ] Interactive scaffolding
+- [x] Interactive scaffolding
 - [ ] Template hot-reload
 - [ ] Better error messages
 - [ ] Development server

--- a/crates/agenterra-cli/Cargo.toml
+++ b/crates/agenterra-cli/Cargo.toml
@@ -18,6 +18,7 @@ serde_json = "1.0"
 serde_yaml = "0.9"
 reqwest = { version = "0.11", features = ["json", "rustls-tls"], default-features = false }
 tempfile = "3.10"
+dialoguer = "0.11"
 
 [[bin]]
 name = "agenterra"

--- a/crates/agenterra-cli/src/main.rs
+++ b/crates/agenterra-cli/src/main.rs
@@ -5,6 +5,8 @@
 use reqwest::Url;
 use std::path::{Path, PathBuf};
 
+use dialoguer::{theme::ColorfulTheme, Input, Select};
+
 // External imports (alphabetized)
 use agenterra_core::{TemplateKind, TemplateManager, TemplateOptions};
 use anyhow::Context;
@@ -53,8 +55,158 @@ pub enum Commands {
         #[arg(long)]
         base_url: Option<Url>,
     },
+    /// Interactive scaffolding flow
+    Init,
     /// List available template kinds
     ListTemplates,
+}
+
+/// Arguments needed to scaffold a project
+#[derive(Clone, Debug)]
+struct ScaffoldArgs {
+    project_name: String,
+    schema_path: String,
+    template_kind: String,
+    template_dir: Option<PathBuf>,
+    output_dir: Option<PathBuf>,
+    log_file: Option<String>,
+    port: Option<u16>,
+    base_url: Option<Url>,
+}
+
+/// Execute the scaffold flow with the provided arguments
+async fn run_scaffold(args: ScaffoldArgs) -> anyhow::Result<()> {
+    // Parse template
+    let template_kind_enum: TemplateKind = args
+        .template_kind
+        .parse()
+        .map_err(|e| anyhow::anyhow!("Invalid template '{}' : {e}", args.template_kind))?;
+
+    // Resolve output directory - use project_name if not specified
+    let output_path = args
+        .output_dir
+        .clone()
+        .unwrap_or_else(|| PathBuf::from(&args.project_name));
+
+    // Debug log template and paths
+    println!(
+        "Scaffolding with template: {}, template_dir: {:?}, output_dir: {:?}",
+        template_kind_enum.as_str(),
+        args.template_dir,
+        output_path
+    );
+
+    // Initialize the template manager using the resolved template directory
+    let template_manager = TemplateManager::new(template_kind_enum, args.template_dir.clone())
+        .await
+        .context("Failed to initialize template manager")?;
+
+    // Create output directory if it doesn't exist
+    if !output_path.exists() {
+        println!("Creating output directory: {}", output_path.display());
+        fs::create_dir_all(&output_path)
+            .await
+            .map_err(|e| anyhow::anyhow!("Failed to create output directory: {}", e))?;
+    }
+
+    // List available templates for debugging
+    println!("Available templates:");
+    for template in template_manager.list_templates() {
+        println!("Source: {} -> Destination: {}", template.0, template.1);
+    }
+
+    println!(
+        "Using templates from: {}",
+        template_manager.template_dir().display()
+    );
+
+    // Create directories for all template file destinations
+    for file in &template_manager.manifest().files {
+        if let Some(parent) = Path::new(&file.destination).parent() {
+            let dir = output_path.join(parent);
+            if !dir.exists() {
+                println!("Creating directory: {}", dir.display());
+                fs::create_dir_all(&dir).await.map_err(|e| {
+                    anyhow::anyhow!("Failed to create directory {}: {}", dir.display(), e)
+                })?;
+            }
+        }
+    }
+
+    // Load the OpenAPI schema from either a file or URL
+    let schema_path = &args.schema_path;
+    println!("Loading OpenAPI schema from: {}", schema_path);
+
+    // Check if the schema_path is a URL or a file path
+    let schema_obj = if schema_path.starts_with("http://") || schema_path.starts_with("https://") {
+        // It's a URL, use from_url
+        let response = reqwest::get(schema_path.as_str()).await.map_err(|e| {
+            anyhow::anyhow!("Failed to fetch OpenAPI schema from {}: {}", schema_path, e)
+        })?;
+
+        if !response.status().is_success() {
+            return Err(anyhow::anyhow!(
+                "Failed to fetch OpenAPI schema from {}: HTTP {}",
+                schema_path,
+                response.status()
+            ));
+        }
+
+        let content = response
+            .text()
+            .await
+            .map_err(|e| anyhow::anyhow!("Failed to read response from {}: {}", schema_path, e))?;
+
+        // Parse the content as OpenAPI schema
+        let temp_dir = tempfile::tempdir()?;
+        let temp_file = temp_dir.path().join("openapi_schema.json");
+        tokio::fs::write(&temp_file, &content).await?;
+
+        agenterra_core::openapi::OpenApiContext::from_file(&temp_file)
+            .await
+            .map_err(|e| {
+                anyhow::anyhow!("Failed to parse OpenAPI schema from {}: {}", schema_path, e)
+            })?
+    } else {
+        // It's a file path
+        agenterra_core::openapi::OpenApiContext::from_file(schema_path)
+            .await
+            .map_err(|e| anyhow::anyhow!("Failed to load OpenAPI schema: {}", e))?
+    };
+
+    // Create config with template
+    let config = agenterra_core::Config {
+        project_name: args.project_name.clone(),
+        openapi_schema_path: schema_path.to_string(),
+        output_dir: output_path.to_string_lossy().to_string(),
+        template_kind: args.template_kind.clone(),
+        template_dir: args
+            .template_dir
+            .as_ref()
+            .map(|p| p.to_string_lossy().to_string()),
+        include_all: true,
+        include_operations: Vec::new(),
+        exclude_operations: Vec::new(),
+        base_url: args.base_url.clone(),
+    };
+
+    // Create template options
+    let template_opts = TemplateOptions {
+        server_port: args.port,
+        log_file: args.log_file.clone(),
+        ..Default::default()
+    };
+
+    // Generate the server using the template manager
+    template_manager
+        .generate(&schema_obj, &config, Some(template_opts))
+        .await?;
+
+    println!(
+        "✅ Successfully generated server in: {}",
+        output_path.display()
+    );
+    Ok(())
 }
 
 #[tokio::main]
@@ -73,138 +225,56 @@ async fn main() -> anyhow::Result<()> {
             port,
             base_url,
         } => {
-            // Parse template
-            let template_kind_enum: TemplateKind = template_kind
-                .parse()
-                .map_err(|e| anyhow::anyhow!("Invalid template '{template_kind}': {e}"))?;
-
-            // Resolve output directory - use project_name if not specified
-            let output_path = output_dir
-                .clone()
-                .unwrap_or_else(|| PathBuf::from(project_name));
-
-            // Debug log template and paths
-            println!(
-                "Scaffolding with template: {}, template_dir: {:?}, output_dir: {:?}",
-                template_kind_enum.as_str(),
-                template_dir,
-                output_path
-            );
-
-            // Initialize the template manager using the resolved template directory
-            let template_manager = TemplateManager::new(template_kind_enum, template_dir.clone())
-                .await
-                .context("Failed to initialize template manager")?;
-
-            // Create output directory if it doesn't exist
-            if !output_path.exists() {
-                println!("Creating output directory: {}", output_path.display());
-                fs::create_dir_all(&output_path)
-                    .await
-                    .map_err(|e| anyhow::anyhow!("Failed to create output directory: {}", e))?;
-            }
-
-            // List available templates for debugging
-            println!("Available templates:");
-            for template in template_manager.list_templates() {
-                println!("Source: {} -> Destination: {}", template.0, template.1);
-            }
-
-            println!(
-                "Using templates from: {}",
-                template_manager.template_dir().display()
-            );
-
-            // Create directories for all template file destinations
-            for file in &template_manager.manifest().files {
-                if let Some(parent) = Path::new(&file.destination).parent() {
-                    let dir = output_path.join(parent);
-                    if !dir.exists() {
-                        println!("Creating directory: {}", dir.display());
-                        fs::create_dir_all(&dir).await.map_err(|e| {
-                            anyhow::anyhow!("Failed to create directory {}: {}", dir.display(), e)
-                        })?;
-                    }
-                }
-            }
-
-            // Load the OpenAPI schema from either a file or URL
-            println!("Loading OpenAPI schema from: {}", schema_path);
-
-            // Check if the schema_path is a URL or a file path
-            let schema_obj = if schema_path.starts_with("http://")
-                || schema_path.starts_with("https://")
-            {
-                // It's a URL, use from_url
-                let response = reqwest::get(schema_path.as_str()).await.map_err(|e| {
-                    anyhow::anyhow!("Failed to fetch OpenAPI schema from {}: {}", schema_path, e)
-                })?;
-
-                if !response.status().is_success() {
-                    return Err(anyhow::anyhow!(
-                        "Failed to fetch OpenAPI schema from {}: HTTP {}",
-                        schema_path,
-                        response.status()
-                    ));
-                }
-
-                let content = response.text().await.map_err(|e| {
-                    anyhow::anyhow!("Failed to read response from {}: {}", schema_path, e)
-                })?;
-
-                // Parse the content as OpenAPI schema
-                // We need to save it to a temporary file since OpenApiContext::from_file expects a file path
-                let temp_dir = tempfile::tempdir()?;
-                let temp_file = temp_dir.path().join("openapi_schema.json");
-                tokio::fs::write(&temp_file, &content).await?;
-
-                agenterra_core::openapi::OpenApiContext::from_file(&temp_file)
-                    .await
-                    .map_err(|e| {
-                        anyhow::anyhow!(
-                            "Failed to parse OpenAPI schema from {}: {}",
-                            schema_path,
-                            e
-                        )
-                    })?
-            } else {
-                // It's a file path
-                agenterra_core::openapi::OpenApiContext::from_file(&schema_path)
-                    .await
-                    .map_err(|e| anyhow::anyhow!("Failed to load OpenAPI schema: {}", e))?
-            };
-
-            // Create config with template
-            let config = agenterra_core::Config {
+            let args = ScaffoldArgs {
                 project_name: project_name.clone(),
-                openapi_schema_path: schema_path.to_string(),
-                output_dir: output_path.to_string_lossy().to_string(),
-                template_kind: template_kind.to_string(),
-                template_dir: template_dir
-                    .as_ref()
-                    .map(|p| p.to_string_lossy().to_string()),
-                include_all: true,              // Include all operations by default
-                include_operations: Vec::new(), // No specific operations to include
-                exclude_operations: Vec::new(), // No operations to exclude
+                schema_path: schema_path.clone(),
+                template_kind: template_kind.clone(),
+                template_dir: template_dir.clone(),
+                output_dir: output_dir.clone(),
+                log_file: log_file.clone(),
+                port: *port,
                 base_url: base_url.clone(),
             };
+            run_scaffold(args).await?;
+        }
+        Commands::Init => {
+            let theme = ColorfulTheme::default();
+            let project_name: String = Input::with_theme(&theme)
+                .with_prompt("Project name")
+                .default("agenterra_mcp_server".into())
+                .interact_text()?;
 
-            // Create template options
-            let template_opts = TemplateOptions {
-                server_port: *port,
-                log_file: log_file.clone(),
-                ..Default::default()
+            let schema_path: String = Input::with_theme(&theme)
+                .with_prompt("Path or URL to OpenAPI schema")
+                .interact_text()?;
+
+            let templates: Vec<String> = TemplateKind::all()
+                .map(|k| k.as_str().to_string())
+                .collect();
+            let selection = Select::with_theme(&theme)
+                .with_prompt("Template kind")
+                .items(&templates)
+                .default(0)
+                .interact()?;
+            let template_kind = templates[selection].clone();
+
+            let default_output = project_name.clone();
+            let output_dir_str: String = Input::with_theme(&theme)
+                .with_prompt("Output directory")
+                .default(default_output)
+                .interact_text()?;
+
+            let args = ScaffoldArgs {
+                project_name,
+                schema_path,
+                template_kind,
+                template_dir: None,
+                output_dir: Some(PathBuf::from(output_dir_str)),
+                log_file: None,
+                port: None,
+                base_url: None,
             };
-
-            // Generate the server using the template manager we already created
-            template_manager
-                .generate(&schema_obj, &config, Some(template_opts))
-                .await?;
-
-            println!(
-                "✅ Successfully generated server in: {}",
-                output_path.display()
-            );
+            run_scaffold(args).await?;
         }
         Commands::ListTemplates => {
             println!("Available template kinds:");

--- a/crates/agenterra-cli/tests/integration_test.rs
+++ b/crates/agenterra-cli/tests/integration_test.rs
@@ -145,6 +145,31 @@ mod tests {
         Ok(())
     }
 
+    #[test]
+    fn test_help_includes_init() -> Result<()> {
+        cleanup_env_vars();
+        let ctx = TestContext::new()?;
+
+        let build_status = Command::new("cargo")
+            .args(["build"])
+            .status()
+            .context("Failed to build agenterra CLI")?;
+        if !build_status.success() {
+            bail!("Failed to build agenterra CLI (status: {})", build_status);
+        }
+
+        let mut cmd = ctx.build_command()?;
+        cmd.arg("--help");
+        let output = cmd.output()?;
+
+        if !output.status.success() {
+            bail!("--help command failed");
+        }
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        assert!(stdout.contains("init"));
+        Ok(())
+    }
+
     // Helper function to clean up environment variables after test
     fn cleanup_env_vars() {
         let env_vars = [

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -8,6 +8,7 @@ This document provides a comprehensive reference for the Agenterra command-line 
 - [Global Options](#global-options)
 - [Commands](#commands)
   - [scaffold](#scaffold)
+  - [init](#init)
 - [Examples](#examples)
 - [Exit Codes](#exit-codes)
 
@@ -57,6 +58,14 @@ agenterra scaffold --spec api.yaml --output generated --template custom --templa
 
 # Configure server port and log file
 agenterra scaffold --spec api.yaml --output generated --port 8080 --log-file my-server
+```
+
+### init
+
+Run an interactive wizard to scaffold a new MCP server.
+
+```bash
+agenterra init
 ```
 
 ## Exit Codes


### PR DESCRIPTION
## Summary
- add an interactive `init` command for the CLI
- document `init` usage in README and CLI reference
- mark interactive scaffolding as complete in ROADMAP
- add dialoguer dependency and shared scaffold logic
- test CLI help output for new command

## Testing
- `cargo fmt`
- `cargo clippy -- -D warnings`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_684e6d0ee94c8328b21175ec3bc24599